### PR TITLE
Merge for version 0-3-0

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,4 +214,4 @@ Year ranges (e.g. `2020-2024`) are supported. Use `--limit N` to cap the number 
 ## Acknowledgements
 This tool is made possible thanks to the efforts of Geert Barentsen who wrote the original version of [kpub](https://github.com/KeplerGO/kpub) for Kepler/K2.  Thanks also to NASA ADS for providing a web API to their database.
 
-Last Update: Today
+Last Update: 15-July-2026

--- a/README.md
+++ b/README.md
@@ -214,3 +214,4 @@ Year ranges (e.g. `2020-2024`) are supported. Use `--limit N` to cap the number 
 ## Acknowledgements
 This tool is made possible thanks to the efforts of Geert Barentsen who wrote the original version of [kpub](https://github.com/KeplerGO/kpub) for Kepler/K2.  Thanks also to NASA ADS for providing a web API to their database.
 
+Last Update: Today

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "jinja2",
     "textract-py3",
     "matplotlib",
-    "pymongo>=4.16.0",
+    "pymongo==3.12.3",
     "bokeh",
     "openpyxl",
     "pandas>=3.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kpub"
-version = "0.1.0"
+version = "0.2.0"
 description = "enables an institution to keep track of it's scientific publications in an easy way."
 authors = [
     {name = "Tyler Tucker",email = "tylertucker202@gmail.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kpub"
-version = "0.2.0"
+version = "0.3.0"
 description = "enables an institution to keep track of it's scientific publications in an easy way."
 authors = [
     {name = "Tyler Tucker",email = "tylertucker202@gmail.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,18 @@ dependencies = [
     "pymongo==3.12.3",
     "bokeh",
     "openpyxl",
+<<<<<<< Updated upstream
     "pandas>=3.0.1",
+=======
+>>>>>>> Stashed changes
 ]
 
 [project.optional-dependencies]
 classifier = [
+<<<<<<< Updated upstream
+=======
+"pandas>=3.0.1",
+>>>>>>> Stashed changes
 "PyMuPDF>=1.25.0",
 "rank-bm25>=0.2.2",
 "sentence-transformers>=5.2.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,18 +17,11 @@ dependencies = [
     "pymongo==3.12.3",
     "bokeh",
     "openpyxl",
-<<<<<<< Updated upstream
     "pandas>=3.0.1",
-=======
->>>>>>> Stashed changes
 ]
 
 [project.optional-dependencies]
 classifier = [
-<<<<<<< Updated upstream
-=======
-"pandas>=3.0.1",
->>>>>>> Stashed changes
 "PyMuPDF>=1.25.0",
 "rank-bm25>=0.2.2",
 "sentence-transformers>=5.2.3",

--- a/scripts/backfill_fulltext.py
+++ b/scripts/backfill_fulltext.py
@@ -1,0 +1,147 @@
+"""
+Backfill the 'fulltext' collection for Keck-affiliation articles.
+
+For each Keck article missing a real fulltext entry (or where the stored
+fulltext is empty / no more than abstract-length), tries to (re-)download and
+extract the fulltext via ADS's link_gateway (EPRINT_PDF/PUB_PDF/EPRINT_HTML/
+PUB_HTML) or, failing that, an ADS metadata query. Only saves the result when
+it's meaningfully longer than the article's abstract; otherwise leaves the
+bibcode as missing/short so it can be retried later (e.g. once better access
+to a given publisher becomes available). Safe to rerun.
+
+Usage:
+    python scripts/backfill_fulltext.py [--limit N] [--sample N] [--dry-run]
+"""
+import argparse
+import collections
+import logging
+import os
+import random
+import sys
+
+import yaml
+
+PACKAGEDIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, PACKAGEDIR)
+
+from kpub import (
+    PublicationDB,
+    get_word_match_counts_by_pdf,
+    get_word_match_counts_by_query,
+)
+
+logging.basicConfig(level=logging.INFO, format='%(levelname)s %(message)s')
+log = logging.getLogger('backfill_fulltext')
+
+
+def needs_fulltext(abstract, existing_fulltext):
+    """A bibcode needs (re-)fetching if it has no fulltext doc, or the stored
+    fulltext is empty, or no more than abstract-length (i.e. likely just a
+    title+abstract restatement rather than real fulltext)."""
+    if existing_fulltext is None:
+        return True
+    stripped = existing_fulltext.strip()
+    if len(stripped) == 0:
+        return True
+    if len(stripped) <= len(abstract or '') + 300:
+        return True
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--limit', type=int, default=None, help='Max number of articles to process')
+    parser.add_argument('--sample', type=int, default=None, help='Randomly sample N articles instead of taking the first N')
+    parser.add_argument('--seed', type=int, default=42, help='Random seed for --sample')
+    parser.add_argument('--dry-run', action='store_true', help='Do not write to the fulltext collection')
+    args = parser.parse_args()
+
+    config = yaml.load(open(f'{PACKAGEDIR}/config/config.live.yaml'), Loader=yaml.FullLoader)
+    ads_api_key = config.get('ADS_API_KEY')
+
+    db = PublicationDB(config, collection='articles')
+
+    keck_articles = list(db.collection.find(
+        {'affiliation': 'keck'}, {'bibcode': 1, 'abstract': 1, '_id': 0}))
+    bibcodes = [a['bibcode'] for a in keck_articles]
+
+    fulltext_collection = db.client['kpub']['fulltext']
+    fulltext_docs = list(fulltext_collection.find(
+        {'bibcode': {'$in': bibcodes}}, {'bibcode': 1, 'fulltext': 1, '_id': 0}))
+    ft_map = {d['bibcode']: d.get('fulltext', '') for d in fulltext_docs}
+
+    todo = []
+    for a in keck_articles:
+        bib = a['bibcode']
+        abstract = a.get('abstract') or ''
+        existing = ft_map.get(bib)
+        if needs_fulltext(abstract, existing):
+            todo.append((bib, abstract, existing))
+
+    log.info(f"{len(todo)} articles need fulltext work (of {len(keck_articles)} keck articles)")
+
+    year_counts_all = collections.Counter(bib[:4] for bib, _, _ in todo)
+    log.info(f"todo by year: {dict(sorted(year_counts_all.items()))}")
+
+    if args.sample:
+        random.seed(args.seed)
+        todo = random.sample(todo, min(args.sample, len(todo)))
+        log.info(f"Randomly sampled {len(todo)} articles for this run (seed={args.seed})")
+    elif args.limit:
+        todo = todo[:args.limit]
+        log.info(f"Limiting to first {len(todo)} articles for this run")
+
+    stats = {'pdf_ok': 0, 'query_ok': 0, 'failed': 0, 'skipped_still_short': 0}
+    year_stats = collections.defaultdict(collections.Counter)
+
+    for idx, (bibcode, abstract, existing) in enumerate(todo):
+        year = bibcode[:4]
+        log.info(f"[{idx+1}/{len(todo)}] Processing {bibcode} "
+                  f"(previously: {'missing' if existing is None else f'{len(existing.strip())} chars'})")
+        fulltext = None
+        source = None
+        try:
+            counts, fulltext = get_word_match_counts_by_pdf(bibcode, [], ads_api_key, [])
+            source = 'pdf/html-download'
+        except Exception as err:
+            log.info(f"  download-based extraction failed: {err}. Trying ADS query fallback...")
+            try:
+                counts, fulltext = get_word_match_counts_by_query(bibcode, [], ads_api_key, [])
+                source = 'ads-query'
+            except Exception as err2:
+                log.warning(f"  ADS query fallback also failed for {bibcode}: {err2}")
+                fulltext = None
+
+        if not fulltext or not fulltext.strip():
+            log.warning(f"  No fulltext obtained for {bibcode}.")
+            stats['failed'] += 1
+            year_stats[year]['failed'] += 1
+            continue
+
+        if needs_fulltext(abstract, fulltext):
+            log.warning(f"  New fulltext for {bibcode} is still short "
+                        f"({len(fulltext.strip())} chars, source={source}); NOT saving, leaving as missing.")
+            stats['skipped_still_short'] += 1
+            year_stats[year]['skipped_still_short'] += 1
+            continue
+
+        if source == 'pdf/html-download':
+            stats['pdf_ok'] += 1
+            year_stats[year]['pdf_ok'] += 1
+        else:
+            stats['query_ok'] += 1
+            year_stats[year]['query_ok'] += 1
+
+        if args.dry_run:
+            log.info(f"  [dry-run] would save {len(fulltext)} chars for {bibcode} (source={source})")
+        else:
+            db.save_fulltext(bibcode, fulltext)
+            log.info(f"  Saved {len(fulltext)} chars for {bibcode} (source={source})")
+
+    log.info(f"Done. stats={stats}")
+    for year in sorted(year_stats):
+        log.info(f"  {year}: {dict(year_stats[year])}")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/db_mongo_conn.py
+++ b/src/db_mongo_conn.py
@@ -260,3 +260,9 @@ class MongoDBConnector:
         }
         count = self.collection.count_documents(query)
         return count
+
+    def get_fulltext(self, bibcodes):
+        """Get full text documents for the given bibcodes."""
+        query = {'bibcode': {'$in': bibcodes}}
+        rows = list(self.collection.find(query))
+        return rows

--- a/src/db_mongo_conn.py
+++ b/src/db_mongo_conn.py
@@ -90,6 +90,7 @@ class MongoDBConnector:
 
             article['last_modifier'] = 'kpub'
             article['date_modified'] = datetime.datetime.now()
+            article['date_created'] = article['date_modified']
             article['month'] = int(month)
             article['year'] = int(year)
             article['mission'] = mission

--- a/src/db_mongo_conn.py
+++ b/src/db_mongo_conn.py
@@ -266,3 +266,17 @@ class MongoDBConnector:
         query = {'bibcode': {'$in': bibcodes}}
         rows = list(self.collection.find(query))
         return rows
+
+    def upsert_fulltext(self, bibcode, fulltext):
+        """Insert or update the extracted plaintext for a publication in the 'fulltext' collection."""
+        fulltext_collection = self.client['kpub']['fulltext']
+        fulltext_collection.update_one(
+            {'_id': bibcode},
+            {'$set': {
+                'bibcode': bibcode,
+                'fulltext': fulltext,
+                'last_updated': datetime.datetime.now(),
+            }},
+            upsert=True
+        )
+        log.info(f"Saved fulltext for {bibcode}")

--- a/src/kpub-viewer/src/App.tsx
+++ b/src/kpub-viewer/src/App.tsx
@@ -30,6 +30,7 @@ export interface Article {
   aff: string[]
   last_modifier: string
   date_modified: string
+  date_created: string
   month: number
   snippits: Snippits
   affiliation: string

--- a/src/kpub-viewer/src/article_table.tsx
+++ b/src/kpub-viewer/src/article_table.tsx
@@ -70,7 +70,14 @@ export const adminColumns = [
             </Tooltip>
         )
     },
-    { field: 'date_modified', headerName: 'DATE_MODIFIED', width: 150 },
+    {
+        field: 'date_created', headerName: 'DATE_CREATED', width: 150,
+        sortComparator: (v1: string, v2: string) => new Date(v1).getTime() - new Date(v2).getTime(),
+    },
+    {
+        field: 'date_modified', headerName: 'DATE_MODIFIED', width: 150,
+        sortComparator: (v1: string, v2: string) => new Date(v1).getTime() - new Date(v2).getTime(),
+    },
     { field: 'last_modifier', headerName: 'LAST_MODIFIER', width: 150 },
     { field: 'has_acknowledgement', headerName: 'Acknowledgement?', width: 70 }
 ]

--- a/src/kpub.py
+++ b/src/kpub.py
@@ -1087,7 +1087,13 @@ def kpub_set_affiliation(articles,
                                   note=note)
     log.info('Set affiliation for {} articles to {}'.format(len(articles), affiliation))
     return articles
-    
+
+def kpub_get_fulltext(bibcodes):
+    """Download the full text of publications using their ADS bibcodes."""
+    config = yaml.load(open(f'{PACKAGEDIR}/config/config.live.yaml'), Loader=yaml.FullLoader)
+    db = PublicationDB(config, collection='fulltext')
+    fulltext_documents = db.get_fulltext(bibcodes)
+    return fulltext_documents
 
 def kpub_export(monthyear, begin_year=None, filename=None, affiliation=None, csv=None, export_all=False):
     """Export the database as JSON format (or CSV if specified)."""

--- a/src/kpub.py
+++ b/src/kpub.py
@@ -1088,8 +1088,9 @@ def kpub_set_affiliation(articles,
     log.info('Set affiliation for {} articles to {}'.format(len(articles), affiliation))
     return articles
 
-def kpub_get_fulltext(bibcodes):
-    """Download the full text of publications using their ADS bibcodes."""
+def kpub_export_fulltext(bibcodes):
+    """Download the full text of publications using their ADS bibcodes. Output
+    comes out as JSON"""
     config = yaml.load(open(f'{PACKAGEDIR}/config/config.live.yaml'), Loader=yaml.FullLoader)
     db = PublicationDB(config, collection='fulltext')
     fulltext_documents = db.get_fulltext(bibcodes)

--- a/src/kpub.py
+++ b/src/kpub.py
@@ -214,10 +214,13 @@ class PublicationDB(MongoDBConnector):
         #try two methods for finding matches
 
         try:
-            counts = get_word_match_counts_by_pdf(bibcode, words, ads_api_key, blacklist)
+            counts, fulltext = get_word_match_counts_by_pdf(bibcode, words, ads_api_key, blacklist)
         except Exception as err:
             log.warning(f"Could not parse PDF file. {err} Using alternate ADS query method...")
-            counts = get_word_match_counts_by_query(bibcode, words, ads_api_key)
+            counts, fulltext = get_word_match_counts_by_query(bibcode, words, ads_api_key, blacklist)
+
+        if fulltext:
+            self.save_fulltext(bibcode, fulltext)
 
         #log.info snippets
         log.info("\nSNIPPETS FOUND:")
@@ -227,6 +230,10 @@ class PublicationDB(MongoDBConnector):
                 log.info(f'"... {snippet}"')
 
         return counts
+
+    def save_fulltext(self, bibcode, fulltext):
+        """Store the extracted plaintext of an article in the 'fulltext' collection."""
+        self.upsert_fulltext(bibcode, fulltext)
 
 
     def get_archive_acknowledgement(self, snippits):
@@ -724,7 +731,13 @@ def request_ads_api(url, ads_api_key, returnResp=False):
     dict
         The JSON response from the ADS API.
     """
-    headers = {'Authorization': f'Bearer {ads_api_key}'}
+    # Some publisher sites reached via ADS's link_gateway (e.g. PUB_HTML/PUB_PDF)
+    # block the default python-requests User-Agent as a bot, even for fully
+    # open-access articles, so pretend to be a browser.
+    headers = {
+        'Authorization': f'Bearer {ads_api_key}',
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36',
+    }
     resp = requests.get(url, headers=headers)
     rateLimitRem = resp.headers.get('X-RateLimit-Remaining', 100)
     if int(rateLimitRem) < 10:
@@ -789,35 +802,36 @@ def display_abstract(article_dict, colors, highlights=None):
     log.info('')
 
 
-def get_word_match_counts_by_query(bibcode, words, ads_api_key):
+def get_word_match_counts_by_query(bibcode, words, ads_api_key, blacklist=None):
+    '''Fetch title/abstract/ack/body text directly from the ADS API (as opposed to
+    parsing a downloaded PDF) and compute word match counts/snippets from it.'''
 
     bibcode = bibcode.replace('&', '%26')
 
-    counts = {}
-    for word in words:
-        word = word.replace(' ', '+')
-        url = (f'{ADS_API}' 
-            f'q=bibcode:%22{bibcode}%22+full:%22{word}%22'
-            "&fl=id,bibcode"
-            "&sort=date+asc"
-            "&hl=true"
-            "&hl.fl=ack,body,title,abstract"
-            "&hl.snippets=4"
-            "&hl.fragsize=100"
-            "&hl.maxAnalyzedChars=500000"
-        )
-        data = request_ads_api(url, ads_api_key)
-        counts[word] = {'count': 0, 'snippets': []}
-        for doc in data.get('response', {}).get('docs',[]):
-            id = doc['id']
-            highlights = data['highlighting'][id]
-            for _, snippets in highlights.items():
-                counts[word]['count'] += len(snippets)
-                counts[word]['snippets'] = snippets
+    url = (f'{ADS_API}'
+        f'q=bibcode:%22{bibcode}%22'
+        "&fl=id,bibcode,title,abstract,ack,body"
+        "&sort=date+asc"
+    )
+    data = request_ads_api(url, ads_api_key)
+    docs = data.get('response', {}).get('docs', [])
+    if not docs:
+        return {}, ''
 
-    #only return counts > 0
-    counts = {key:val for key, val in counts.items() if val['count'] != 0}
-    return counts
+    doc = docs[0]
+    fulltext_parts = []
+    for field in ('title', 'abstract', 'ack', 'body'):
+        value = doc.get(field)
+        if not value:
+            continue
+        if isinstance(value, list):
+            fulltext_parts.extend(str(v) for v in value)
+        else:
+            fulltext_parts.append(str(value))
+    fulltext = "\n".join(fulltext_parts)
+
+    counts = get_word_match_counts_from_text(fulltext, words, blacklist)
+    return counts, fulltext
  
 
 def get_word_match_counts_from_text(text, words, blacklist=None):
@@ -841,28 +855,59 @@ def get_word_match_counts_by_pdf(bibcode, words, ads_api_key, blacklist=[]):
 
     #get pdf file and text
     outfile = get_pdf_file(bibcode, ads_api_key)
+    if not outfile:
+        raise Exception(f"Could not download fulltext for {bibcode}")
     text = get_pdf_text(outfile)
     text = text.replace("\n",' ')
     text = text.replace("\r",' ')
     text = re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\xff]', ' ', text)
-    return get_word_match_counts_from_text(text, words, blacklist)
+    counts = get_word_match_counts_from_text(text, words, blacklist)
+    return counts, text
   
 
-def get_pdf_file(bibcode, ads_api_key):
+# ADS link_gateway esources to try for fulltext, in order of preference.
+# EPRINT_* points to the arXiv copy; PUB_* points to the publisher's copy
+# (needed for e.g. open-access journal articles that have no arXiv preprint).
+FULLTEXT_ESOURCES = ['EPRINT_PDF', 'PUB_PDF', 'EPRINT_HTML', 'PUB_HTML']
 
-    outfile = f'/tmp/{bibcode}.pdf'
-    if os.path.isfile(outfile):
+def get_pdf_file(bibcode, ads_api_key):
+    '''Download the fulltext of an article, trying each esource in
+    FULLTEXT_ESOURCES until one succeeds. Returns the path to the downloaded
+    file (.pdf or .html depending on the esource used), or False if none worked.'''
+
+    for esource in FULLTEXT_ESOURCES:
+        ext = 'pdf' if 'PDF' in esource else 'html'
+        outfile = f'/tmp/{bibcode}.{ext}'
+        if os.path.isfile(outfile):
+            return outfile
+
+        log.info(f'\nRetrieving fulltext via {esource} (May take up to a minute)...')
+        url = f'https://ui.adsabs.harvard.edu/link_gateway/{bibcode}/{esource}'
+        try:
+            resp = request_ads_api(url, ads_api_key, returnResp=True)
+        except Exception as err:
+            log.info(f"{esource} gateway failed for {bibcode}: {err}")
+            continue
+        if resp.status_code != 200 or len(resp.content) < 1000:
+            continue
+
+        # Publisher gateways sometimes 200 with a paywall/verification page
+        # instead of the real file, so check the returned type matches what
+        # this esource is supposed to be before trusting it.
+        content_type = resp.headers.get('Content-Type', '').lower()
+        if ext == 'pdf' and 'pdf' not in content_type:
+            log.info(f"{esource} for {bibcode} returned Content-Type '{content_type}', not a PDF. Skipping.")
+            continue
+        if ext == 'html' and 'html' not in content_type:
+            log.info(f"{esource} for {bibcode} returned Content-Type '{content_type}', not HTML. Skipping.")
+            continue
+
+        with open(outfile, 'wb') as f:
+             f.write(resp.content)
         return outfile
 
-    log.info('\nRetrieving PDF (May take up to a minute)...')
-    url = f'https://ui.adsabs.harvard.edu/link_gateway/{bibcode}/EPRINT_PDF'
-    resp = request_ads_api(url, ads_api_key, returnResp=True)
-    if resp.status_code != 200 or len(resp.content) < 1000:
-        print("Could not download PDF file.")
-        return False
-    with open(outfile, 'wb') as f:
-         f.write(resp.content)
-    return outfile
+    log.warning(f"Could not download fulltext for {bibcode} via any esource.")
+    return False
 
 def kpub_update_citations(year):
     """Updates the citation counts for all articles in the database for a given year.
@@ -910,7 +955,13 @@ def get_citation_fields(bibcode, ads_api_key):
 
 
 def get_pdf_text(outfile):
+    '''Extract plaintext from a downloaded fulltext file (.pdf or .html).'''
     assert textract, "No textract module found."
+
+    if outfile.endswith('.html'):
+        text = textract.process(outfile)
+        return text.decode("utf-8")
+
     methods = ['pdftotext', 'pdfminer']
     text = ''
     for method in methods:

--- a/src/kpub.py
+++ b/src/kpub.py
@@ -89,10 +89,11 @@ class PublicationDB(MongoDBConnector):
     filename : str
         Path to the SQLite database file.
     """
-    def __init__(self, config=None):
+    def __init__(self, config=None, collection=None):
         self.config = config
+        self.collection = collection if collection else None 
         #super().__init__(filename)
-        super().__init__(self.config, 'kpub')
+        super().__init__(self.config, 'kpub', collection=self.collection)
 
     def add(self, article, mission, snippits, instruments, archive, affiliation, reason, hasAcknowledgement):
         """Adds a single article object to the database.

--- a/src/kpub.py
+++ b/src/kpub.py
@@ -175,8 +175,8 @@ class PublicationDB(MongoDBConnector):
 
         instruments = ''
         if len(snippits) == 0:
-            log.info("No snippets found.  Marking as unrelated.")
-            mission = 'unrelated'
+            log.info("No snippets found.  Marking as unknown.")
+            mission = 'unknown'
         instruments = "|".join([ x for x in snippits.keys() if x in self.config['instruments']])
 
         # Get archive ack
@@ -842,10 +842,10 @@ def get_word_match_counts_from_text(text, words, blacklist=None):
         for ch in (' ', '/', '\(', '-', ':'):
             find = f"{ch}{word}"
             for match in re.finditer(find, text):
-                snip = text[match.start()-5:match.end()+5]
+                snip = text[max(match.start()-5, 0):match.end()+5]
                 if any(bl in snip for bl in blacklist):
                     continue
-                snippet = text[match.start()-80:match.end()+80]
+                snippet = text[max(match.start()-80, 0):match.end()+80]
                 counts[word]['count'] += 1
                 counts[word]['snippets'].append(snippet)
     return {key: val for key, val in counts.items() if val['count'] != 0}
@@ -858,6 +858,8 @@ def get_word_match_counts_by_pdf(bibcode, words, ads_api_key, blacklist=[]):
     if not outfile:
         raise Exception(f"Could not download fulltext for {bibcode}")
     text = get_pdf_text(outfile)
+    if not text:
+        raise Exception(f"No text could be extracted from downloaded fulltext for {bibcode}")
     text = text.replace("\n",' ')
     text = text.replace("\r",' ')
     text = re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\xff]', ' ', text)
@@ -1104,17 +1106,13 @@ def kpub_import(jsonfile):
 
     db = PublicationDB(config)
     with open(jsonfile, 'r') as f:
-        rows = json.load()
+        rows = json.load(f)
     for row in rows:
         try:
-            bibcode = row['bibcode'] 
-            mission = row['mission'] 
-            instrs  = row['instruments'] 
-            archive = row['archive'] 
-            db.add_by_bibcode(bibcode, mission=mission,
-                instruments=instrs, archive=archive, interactive=False)
+            bibcode = row['bibcode']
+            db.add_by_bibcode(bibcode, interactive=False)
         except Exception as err:
-            log.warning("attempt #{} for {}: error '{}'".format(row, err))
+            log.warning("Could not import {}: error '{}'".format(row, err))
 
     #all done
     log.info(f'\nFinished importing.')
@@ -1194,7 +1192,7 @@ def kpub_spreadsheet(filename):
 
     config = yaml.load(open(f'{PACKAGEDIR}/config/config.live.yaml'), Loader=yaml.FullLoader)
 
-    db = PublicationDB(filename, config)
+    db = PublicationDB(config)
     spreadsheet = []
     rows = db.select_for_spreadsheet()
     for row in rows:
@@ -1242,7 +1240,7 @@ def kpub_spreadsheet(filename):
                     ])
         spreadsheet.append(myrow)
 
-    output_fn = 'kpub-publications.xlsx'
+    output_fn = filename
     log.info('Writing to {}'.format(output_fn))
     wb = Workbook()
     ws = wb.active

--- a/src/kpub.py
+++ b/src/kpub.py
@@ -233,6 +233,9 @@ class PublicationDB(MongoDBConnector):
 
     def save_fulltext(self, bibcode, fulltext):
         """Store the extracted plaintext of an article in the 'fulltext' collection."""
+        if not fulltext or not fulltext.strip():
+            log.warning(f"Not saving fulltext for {bibcode}: extracted text is empty/blank.")
+            return
         self.upsert_fulltext(bibcode, fulltext)
 
 
@@ -970,10 +973,10 @@ def get_pdf_text(outfile):
         try:
             text = textract.process(outfile, method=method)
             text = text.decode("utf-8")
-            if text: return text
+            if text.strip(): return text
         except Exception as e:
             log.info(f"textract: {method} method failed.  Trying another method...")
-    if not text:
+    if not text.strip():
         raise Exception("Could not extract PDF text")
 
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,0 +1,62 @@
+"""Shared pytest fixtures for the mocked kpub unit tests.
+
+These fixtures make sure no test in this package ever touches a real
+MongoDB instance: MongoDBConnector.connect() is replaced with a fake
+that hands out MagicMock() 'client'/'collection' objects instead of
+opening a real network connection.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+import kpub as kpub_module
+from kpub import PublicationDB
+
+
+@pytest.fixture(autouse=True)
+def no_real_mongo(monkeypatch):
+    """Replace MongoDBConnector.connect so no test ever opens a real connection."""
+    def fake_connect(self, database, collection):
+        self.client = MagicMock(name='mongo_client')
+        self.collection = MagicMock(name='mongo_collection')
+
+    monkeypatch.setattr(kpub_module.MongoDBConnector, 'connect', fake_connect)
+
+
+@pytest.fixture
+def config():
+    """A minimal but representative config dict, mirroring config.live.yaml."""
+    return {
+        'kpub': {
+            'server': 'localhost',
+            'port': 27017,
+            'user': '',
+            'pwd': '',
+            'database': 'kpub',
+            'collection': 'articles',
+        },
+        'ADS_API_KEY': 'FAKE-ADS-API-KEY',
+        'prepend': 'keck',
+        'missions': ['keck'],
+        'sciences': [],
+        'ads_queries': [
+            {'name': 'Ackn/Abstract', 'query': '(ack:keck OR abs:keck)'},
+        ],
+        'instruments': ['HIRES', 'LRIS'],
+        'blacklist': ['THESIS'],
+        'archive': ['KOA'],
+        'acknowledgement': ['W. M. Keck Foundation'],
+        'colors': {'HIRES': 'CYAN', 'KOA': 'YELLOW', 'KECK': 'GREEN'},
+        'plots': {'year_begin': 2009, 'instruments': ['HIRES']},
+        'aff_defs': [
+            {'type': 'keck', 'strings': ['Keck', 'Caltech']},
+            {'type': 'usa', 'strings': ['NASA']},
+            {'type': 'intl', 'strings': []},
+        ],
+    }
+
+
+@pytest.fixture
+def db(config):
+    """A PublicationDB instance whose .client/.collection are MagicMocks."""
+    return PublicationDB(config=config, collection='articles')

--- a/src/tests/test_kpub_cli.py
+++ b/src/tests/test_kpub_cli.py
@@ -1,0 +1,405 @@
+"""Unit tests for kpub's top-level CLI wrapper functions and helpers.
+
+Each kpub_* function here reads the real config.live.yaml (a local repo
+file -- no network/credentials are ever used) and then constructs a
+PublicationDB. To guarantee no test touches a real MongoDB instance, every
+test in this file replaces kpub.PublicationDB itself with a MagicMock
+class, so the constructor never runs and every DB call is a mock we can
+assert against.
+"""
+import datetime
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+import kpub as kpub_module
+from kpub import (
+    kpub_add,
+    kpub_delete,
+    kpub_export,
+    kpub_export_fulltext,
+    kpub_import,
+    kpub_plot,
+    kpub_plot_data,
+    kpub_set_affiliation,
+    kpub_spreadsheet,
+    kpub_stats,
+    kpub_update,
+    make_parser,
+    serialize_datetime,
+)
+
+
+@pytest.fixture(autouse=True)
+def mock_publication_db(monkeypatch):
+    """Replace PublicationDB with a MagicMock class for every test in this file."""
+    mock_cls = MagicMock(name='PublicationDB_class')
+    monkeypatch.setattr(kpub_module, 'PublicationDB', mock_cls)
+    return mock_cls
+
+
+# ---------------------------------------------------------------------------
+# serialize_datetime
+# ---------------------------------------------------------------------------
+
+def test_serialize_datetime_returns_isoformat():
+    dt = datetime.datetime(2020, 5, 1, 12, 30)
+    assert serialize_datetime(dt) == dt.isoformat()
+
+
+def test_serialize_datetime_raises_for_non_datetime():
+    with pytest.raises(TypeError):
+        serialize_datetime('not a date')
+
+
+# ---------------------------------------------------------------------------
+# kpub_stats
+# ---------------------------------------------------------------------------
+
+def test_kpub_stats_writes_overview_and_saves_markdown_twice(mock_publication_db, monkeypatch, tmp_path):
+    monkeypatch.setattr(kpub_module, 'MDDIR', str(tmp_path))
+    pubdb = mock_publication_db.return_value
+    pubdb.get_metrics.return_value = {
+        'publication_count': 10, 'refereed_count': 8, 'citation_count': 100, 'author_count': 5,
+    }
+    pubdb.get_most_cited.return_value = []
+    pubdb.get_most_active_first_authors.return_value = []
+
+    kpub_stats()
+
+    assert pubdb.save_markdown.call_count == 2
+    overview = tmp_path / 'publications-overview.md'
+    assert overview.exists()
+    content = overview.read_text()
+    assert '10 publications' in content
+    assert '8 are peer-reviewed' in content
+
+
+# ---------------------------------------------------------------------------
+# kpub_plot_data / kpub_plot
+# ---------------------------------------------------------------------------
+
+def test_kpub_plot_data_delegates_to_db(mock_publication_db):
+    pubdb = mock_publication_db.return_value
+    pubdb.get_plot_data.return_value = {'x': [1, 2, 3]}
+
+    result = kpub_plot_data('plot_by_year', instruments='HIRES', year_begin=2015, extrapolate=True)
+
+    assert result == {'x': [1, 2, 3]}
+    pubdb.get_plot_data.assert_called_once_with(
+        plotname='plot_by_year', instruments='HIRES', extrapolate=True, year_begin=2015)
+
+
+def test_kpub_plot_calls_get_plot(mock_publication_db):
+    pubdb = mock_publication_db.return_value
+
+    kpub_plot()
+
+    pubdb.get_plot.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# kpub_update
+# ---------------------------------------------------------------------------
+
+def test_kpub_update_returns_db_update_result(mock_publication_db):
+    pubdb = mock_publication_db.return_value
+    pubdb.update.return_value = (True, 7)
+
+    result = kpub_update('2020-05')
+
+    assert result == (True, 7)
+    pubdb.update.assert_called_once_with(month='2020-05')
+
+
+# ---------------------------------------------------------------------------
+# kpub_add / kpub_delete
+# ---------------------------------------------------------------------------
+
+def test_kpub_add_adds_each_bibcode(mock_publication_db):
+    pubdb = mock_publication_db.return_value
+
+    kpub_add(['2020ApJ...1A', '2020ApJ...2B'], interactive=True)
+
+    assert pubdb.add_by_bibcode.call_count == 2
+    pubdb.add_by_bibcode.assert_any_call('2020ApJ...1A', interactive=True)
+    pubdb.add_by_bibcode.assert_any_call('2020ApJ...2B', interactive=True)
+
+
+def test_kpub_delete_deletes_each_bibcode(mock_publication_db):
+    pubdb = mock_publication_db.return_value
+
+    kpub_delete(['2020ApJ...1A', '2020ApJ...2B'])
+
+    assert pubdb.delete_by_bibcode.call_count == 2
+    pubdb.delete_by_bibcode.assert_any_call('2020ApJ...1A')
+    pubdb.delete_by_bibcode.assert_any_call('2020ApJ...2B')
+
+
+# ---------------------------------------------------------------------------
+# kpub_import
+# ---------------------------------------------------------------------------
+
+def test_kpub_import_adds_each_row_by_bibcode(mock_publication_db, tmp_path):
+    pubdb = mock_publication_db.return_value
+    jsonfile = tmp_path / 'rows.json'
+    jsonfile.write_text(json.dumps([
+        {'bibcode': '2020ApJ...1A', 'mission': 'keck'},
+        {'bibcode': '2020ApJ...2B', 'mission': 'keck'},
+    ]))
+
+    kpub_import(str(jsonfile))
+
+    assert pubdb.add_by_bibcode.call_count == 2
+    pubdb.add_by_bibcode.assert_any_call('2020ApJ...1A', interactive=False)
+    pubdb.add_by_bibcode.assert_any_call('2020ApJ...2B', interactive=False)
+
+
+def test_kpub_import_logs_and_continues_on_row_error(mock_publication_db, tmp_path, caplog):
+    pubdb = mock_publication_db.return_value
+    pubdb.add_by_bibcode.side_effect = [Exception('ADS lookup failed'), None]
+    jsonfile = tmp_path / 'rows.json'
+    jsonfile.write_text(json.dumps([
+        {'bibcode': '2020ApJ...1A'},
+        {'bibcode': '2020ApJ...2B'},
+    ]))
+
+    with caplog.at_level('WARNING', logger='KPUB'):
+        kpub_import(str(jsonfile))
+
+    assert pubdb.add_by_bibcode.call_count == 2
+    assert any('Could not import' in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# kpub_set_affiliation
+# ---------------------------------------------------------------------------
+
+def test_kpub_set_affiliation_delegates_to_db(mock_publication_db):
+    pubdb = mock_publication_db.return_value
+    pubdb.set_affiliation.return_value = [{'bibcode': '2020ApJ...1A', 'affiliation': 'keck'}]
+
+    result = kpub_set_affiliation(
+        [{'bibcode': '2020ApJ...1A'}], 'tester', affiliation='keck',
+        koa_affiliation=True, instruments=['HIRES'], note='a note')
+
+    assert result == [{'bibcode': '2020ApJ...1A', 'affiliation': 'keck'}]
+    pubdb.set_affiliation.assert_called_once_with(
+        [{'bibcode': '2020ApJ...1A'}], 'tester', affiliation='keck',
+        koa_affiliation=True, instruments=['HIRES'], note='a note')
+
+
+# ---------------------------------------------------------------------------
+# kpub_export_fulltext
+# ---------------------------------------------------------------------------
+
+def test_kpub_export_fulltext_uses_fulltext_collection(mock_publication_db):
+    pubdb = mock_publication_db.return_value
+    pubdb.get_fulltext.return_value = [{'bibcode': '2020ApJ...1A', 'fulltext': 'text'}]
+
+    result = kpub_export_fulltext(['2020ApJ...1A'])
+
+    assert result == [{'bibcode': '2020ApJ...1A', 'fulltext': 'text'}]
+    assert mock_publication_db.call_args.kwargs['collection'] == 'fulltext'
+    pubdb.get_fulltext.assert_called_once_with(['2020ApJ...1A'])
+
+
+# ---------------------------------------------------------------------------
+# kpub_export
+# ---------------------------------------------------------------------------
+
+def test_kpub_export_all_ignores_month_filters(mock_publication_db):
+    pubdb = mock_publication_db.return_value
+    pubdb.get_articles.return_value = [{'bibcode': '2020ApJ...1A'}]
+
+    result = kpub_export('2020-05', affiliation='keck', export_all=True)
+
+    assert result == [{'bibcode': '2020ApJ...1A'}]
+    pubdb.get_articles.assert_called_once_with(affiliation='keck')
+
+
+def test_kpub_export_returns_empty_list_when_no_articles(mock_publication_db):
+    pubdb = mock_publication_db.return_value
+    pubdb.get_articles.return_value = []
+
+    result = kpub_export('2020-05')
+
+    assert result == []
+
+
+def test_kpub_export_writes_json_file_with_datetime_serialization(mock_publication_db, tmp_path):
+    pubdb = mock_publication_db.return_value
+    pubdb.get_articles.return_value = [
+        {'bibcode': '2020ApJ...1A', 'date_modified': datetime.datetime(2020, 1, 1, 12, 0, 0)}
+    ]
+    out_file = tmp_path / 'export.json'
+
+    kpub_export('2020-05', filename=str(out_file))
+
+    written = json.loads(out_file.read_text())
+    assert written[0]['bibcode'] == '2020ApJ...1A'
+    assert written[0]['date_modified'] == datetime.datetime(2020, 1, 1, 12, 0, 0).isoformat()
+
+
+def test_kpub_export_writes_csv_file(mock_publication_db, tmp_path):
+    pubdb = mock_publication_db.return_value
+    pubdb.get_articles.return_value = [{'bibcode': '2020ApJ...1A', 'year': 2020}]
+    out_file = tmp_path / 'export.csv'
+
+    kpub_export('2020-05', filename=str(out_file), csv=True)
+
+    content = out_file.read_text()
+    assert 'bibcode' in content
+    assert '2020ApJ...1A' in content
+
+
+def test_kpub_export_parses_monthyear_and_begin_year(mock_publication_db):
+    pubdb = mock_publication_db.return_value
+    pubdb.get_articles.return_value = [{'bibcode': 'A'}]
+
+    kpub_export('2020-05', begin_year='2018', affiliation=None)
+
+    pubdb.get_articles.assert_called_once_with(
+        begin_year=2018, end_year=2020, month=5, affiliation=None)
+
+
+# ---------------------------------------------------------------------------
+# kpub_spreadsheet
+# ---------------------------------------------------------------------------
+
+class _FakeWorksheet:
+    def __init__(self):
+        self.rows = []
+
+    def append(self, values):
+        self.rows.append(list(values))
+
+    def __getitem__(self, key):
+        return []
+
+
+class _FakeWorkbook:
+    def __init__(self):
+        self.active = _FakeWorksheet()
+        self.saved_to = None
+
+    def save(self, filename):
+        self.saved_to = filename
+
+
+def test_kpub_spreadsheet_computes_refereed_label_and_citations_per_year(
+        mock_publication_db, monkeypatch):
+    fake_wb = _FakeWorkbook()
+    monkeypatch.setattr('openpyxl.Workbook', MagicMock(return_value=fake_wb))
+
+    pubdb = mock_publication_db.return_value
+    old_date = (datetime.datetime.now() - datetime.timedelta(days=365)).strftime('%Y-%m-00')
+    pubdb.select_for_spreadsheet.return_value = [
+        {
+            'bibcode': '2020ApJ...1A', 'year': 2020, 'date': old_date, 'mission': 'keck',
+            'date_modified': datetime.datetime(2020, 1, 1), 'last_modifier': 'kpub',
+            'property': ['REFEREED'], 'citation_count': 10, 'read_count': 100,
+            'first_author_norm': 'Smith, J.', 'title': ['A great paper'],
+            'keyword_norm': None, 'keyword': None, 'abstract': 'abstract text',
+            'author_norm': ['Smith, J.'], 'instruments': ['HIRES'], 'archive': False,
+            'affiliation': 'keck', 'aff': ['Keck Observatory'],
+        },
+        {
+            'bibcode': '2020ApJ...2B', 'year': 2020, 'date': old_date, 'mission': 'keck',
+            'date_modified': datetime.datetime(2020, 1, 1), 'last_modifier': 'kpub',
+            'property': ['NOT REFEREED'], 'citation_count': None, 'read_count': 5,
+            'first_author_norm': 'Doe, A.', 'title': ['Another paper'],
+            'keyword_norm': None, 'keyword': None, 'abstract': 'abstract text 2',
+            'author_norm': ['Doe, A.'], 'instruments': [], 'archive': False,
+            'affiliation': 'keck', 'aff': ['Keck Observatory'],
+        },
+    ]
+
+    kpub_spreadsheet('my-export.xlsx')
+
+    # PublicationDB must be constructed with just the config dict (not the filename)
+    mock_publication_db.assert_called_once()
+    call_args = mock_publication_db.call_args[0]
+    assert len(call_args) == 1
+    assert isinstance(call_args[0], dict)
+    # and the workbook must be saved to the requested filename, not a hardcoded one
+    assert fake_wb.saved_to == 'my-export.xlsx'
+
+    header, row1, row2 = fake_wb.active.rows
+    assert header[0] == 'bibcode'
+    refereed_idx = header.index('refereed')
+    citations_per_year_idx = header.index('citations_per_year')
+    assert row1[refereed_idx] == 'REFEREED'
+    assert row1[citations_per_year_idx] == pytest.approx(10 / 1, rel=0.05)
+    assert row2[refereed_idx] == 'NOT REFEREED'
+    assert row2[citations_per_year_idx] == 0  # citation_count None -> TypeError -> falls back to 0
+
+
+# ---------------------------------------------------------------------------
+# make_parser
+# ---------------------------------------------------------------------------
+
+def test_make_parser_update_subcommand():
+    parser = make_parser()
+    args = parser.parse_args(['update', '2020-05'])
+    assert args.command == 'update'
+    assert args.month == '2020-05'
+
+
+def test_make_parser_update_subcommand_month_optional():
+    parser = make_parser()
+    args = parser.parse_args(['update'])
+    assert args.month is None
+
+
+def test_make_parser_add_subcommand_with_interactive_flag():
+    parser = make_parser()
+    args = parser.parse_args(['add', '2020ApJ...1A', '2020ApJ...2B', '-interactive'])
+    assert args.bibcode == ['2020ApJ...1A', '2020ApJ...2B']
+    assert args.interactive is True
+
+
+def test_make_parser_delete_subcommand():
+    parser = make_parser()
+    args = parser.parse_args(['delete', '2020ApJ...1A'])
+    assert args.bibcode == ['2020ApJ...1A']
+
+
+def test_make_parser_export_subcommand_defaults():
+    parser = make_parser()
+    args = parser.parse_args(['export'])
+    assert args.command == 'export'
+    assert args.csv is False
+    assert args.all is False
+
+
+def test_make_parser_export_subcommand_with_all_flag():
+    parser = make_parser()
+    args = parser.parse_args(['export', '2020-05', '-csv', '--all'])
+    assert args.csv is True
+    assert args.all is True
+
+
+def test_make_parser_stats_and_plot_subcommands():
+    parser = make_parser()
+    assert parser.parse_args(['stats']).command == 'stats'
+    assert parser.parse_args(['plot']).command == 'plot'
+
+
+def test_make_parser_update_citations_subcommand():
+    parser = make_parser()
+    args = parser.parse_args(['update_citations', '2020'])
+    assert args.year == 2020
+
+
+def test_make_parser_spreadsheet_subcommand_requires_filename():
+    parser = make_parser()
+    args = parser.parse_args(['spreadsheet', 'out.xlsx'])
+    assert args.filename == 'out.xlsx'
+
+
+def test_make_parser_requires_a_command():
+    parser = make_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args([])

--- a/src/tests/test_kpub_helpers.py
+++ b/src/tests/test_kpub_helpers.py
@@ -1,0 +1,432 @@
+"""Unit tests for the module-level helper functions in kpub.py.
+
+None of these hit the network or a real database; external calls
+(requests, textract, readline) are mocked.
+"""
+import datetime
+from unittest.mock import MagicMock, call
+
+import pytest
+
+import kpub as kpub_module
+from kpub import (
+    add_prompt_valmaps,
+    get_citation_fields,
+    get_pdf_file,
+    get_pdf_text,
+    get_word_match_counts_by_pdf,
+    get_word_match_counts_by_query,
+    get_word_match_counts_from_text,
+    highlight_text,
+    input_with_prefill,
+    kpub_update_citations,
+    prompt_grouping,
+    request_ads_api,
+    update_citations,
+)
+
+
+# ---------------------------------------------------------------------------
+# highlight_text
+# ---------------------------------------------------------------------------
+
+def test_highlight_text_wraps_matches_with_color_codes():
+    colors = {'KECK': 'GREEN'}
+    result = highlight_text('The KECK Observatory', colors)
+    assert kpub_module.HIGHLIGHTS['GREEN'] in result
+    assert kpub_module.HIGHLIGHTS['END'] in result
+    assert 'KECK' in result
+
+
+def test_highlight_text_is_case_insensitive():
+    colors = {'keck': 'RED'}
+    result = highlight_text('KECK observatory', colors)
+    assert kpub_module.HIGHLIGHTS['RED'] in result
+
+
+def test_highlight_text_no_match_returns_original_text():
+    colors = {'NIRSPEC': 'CYAN'}
+    result = highlight_text('nothing relevant here', colors)
+    assert result == 'nothing relevant here'
+
+
+def test_highlight_text_coerces_non_string_input():
+    colors = {'123': 'RED'}
+    result = highlight_text(12345, colors)
+    assert kpub_module.HIGHLIGHTS['RED'] in result
+    assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# get_word_match_counts_from_text
+# ---------------------------------------------------------------------------
+
+def test_get_word_match_counts_from_text_counts_matches():
+    text = "We used the HIRES spectrograph and later the HIRES data again."
+    counts = get_word_match_counts_from_text(text, ['HIRES'])
+    assert counts['HIRES']['count'] == 2
+    assert len(counts['HIRES']['snippets']) == 2
+
+
+def test_get_word_match_counts_from_text_excludes_words_with_zero_matches():
+    text = "Nothing relevant is mentioned here."
+    counts = get_word_match_counts_from_text(text, ['HIRES', 'LRIS'])
+    assert counts == {}
+
+
+def test_get_word_match_counts_from_text_respects_blacklist():
+    # "-ESING" contains "-ESI" so it would match the ESI instrument via the
+    # '-' separator; the blacklist should suppress that specific snippet.
+    text = "This is not about ESI, it's about proc-ESING results."
+    counts = get_word_match_counts_from_text(text, ['ESI'], blacklist=['ESING'])
+    # The genuine ", ESI" match should still be counted, but not the ESING one.
+    assert counts['ESI']['count'] == 1
+
+
+def test_get_word_match_counts_from_text_matches_multiple_separators():
+    text = "keck/HIRES keck-HIRES (HIRES keck:HIRES"
+    counts = get_word_match_counts_from_text(text, ['HIRES'])
+    assert counts['HIRES']['count'] == 4
+
+
+def test_get_word_match_counts_from_text_match_near_start_gives_correct_snippet():
+    # Regression test: match.start() - 80 (and - 5) used to go negative for
+    # matches near the start of the text, which Python silently wraps around
+    # to slice from the end of the string instead of clamping to index 0.
+    text = "Observations with (ESI) confirmed the result." + ("x" * 200)
+    counts = get_word_match_counts_from_text(text, ['ESI'])
+    assert counts['ESI']['count'] == 1
+    snippet = counts['ESI']['snippets'][0]
+    # A correctly-clamped snippet starts at index 0 of the text; the old,
+    # unclamped negative-index slice instead started ~80 chars before the
+    # end of the string, deep inside the trailing run of "x"s.
+    assert snippet.startswith("Observations with (ESI)")
+
+
+# ---------------------------------------------------------------------------
+# request_ads_api
+# ---------------------------------------------------------------------------
+
+def _fake_response(json_data=None, status_ok=True, remaining='100', reset=None, content=b''):
+    resp = MagicMock()
+    resp.headers = {'X-RateLimit-Remaining': remaining}
+    if reset is not None:
+        resp.headers['X-RateLimit-Reset'] = reset
+    resp.content = content
+    if status_ok:
+        resp.raise_for_status.return_value = None
+    else:
+        import requests
+        resp.raise_for_status.side_effect = requests.HTTPError('boom')
+    resp.json.return_value = json_data if json_data is not None else {}
+    return resp
+
+
+def test_request_ads_api_returns_json_by_default(monkeypatch):
+    resp = _fake_response(json_data={'response': {'docs': []}})
+    mock_get = MagicMock(return_value=resp)
+    monkeypatch.setattr(kpub_module.requests, 'get', mock_get)
+
+    data = request_ads_api('http://example.test/query', 'MYKEY')
+
+    assert data == {'response': {'docs': []}}
+    called_headers = mock_get.call_args.kwargs['headers']
+    assert called_headers['Authorization'] == 'Bearer MYKEY'
+    assert 'Mozilla' in called_headers['User-Agent']
+
+
+def test_request_ads_api_returns_response_object_when_requested(monkeypatch):
+    resp = _fake_response(json_data={'ok': True})
+    monkeypatch.setattr(kpub_module.requests, 'get', MagicMock(return_value=resp))
+
+    result = request_ads_api('http://example.test/query', 'MYKEY', returnResp=True)
+
+    assert result is resp
+    resp.json.assert_not_called()
+
+
+def test_request_ads_api_warns_on_low_rate_limit(monkeypatch, caplog):
+    epoch = int(datetime.datetime.now().timestamp())
+    resp = _fake_response(json_data={}, remaining='5', reset=str(epoch))
+    monkeypatch.setattr(kpub_module.requests, 'get', MagicMock(return_value=resp))
+
+    with caplog.at_level('WARNING', logger='KPUB'):
+        request_ads_api('http://example.test/query', 'MYKEY')
+
+    assert any('Rate limit remaining' in rec.message for rec in caplog.records)
+
+
+def test_request_ads_api_raises_on_http_error(monkeypatch):
+    resp = _fake_response(json_data={}, status_ok=False)
+    monkeypatch.setattr(kpub_module.requests, 'get', MagicMock(return_value=resp))
+
+    import requests
+    with pytest.raises(requests.HTTPError):
+        request_ads_api('http://example.test/query', 'MYKEY')
+
+
+# ---------------------------------------------------------------------------
+# get_word_match_counts_by_query
+# ---------------------------------------------------------------------------
+
+def test_get_word_match_counts_by_query_concatenates_fields(monkeypatch):
+    fake_data = {
+        'response': {
+            'docs': [{
+                'title': ['A great HIRES paper'],
+                'abstract': 'We observed with HIRES.',
+                'ack': ['Thanks to Keck'],
+                'body': 'The HIRES spectrograph was used throughout the body.',
+            }]
+        }
+    }
+    monkeypatch.setattr(kpub_module, 'request_ads_api', MagicMock(return_value=fake_data))
+
+    counts, fulltext = get_word_match_counts_by_query('2020ApJ...1A', ['HIRES'], 'KEY')
+
+    assert 'A great HIRES paper' in fulltext
+    assert 'We observed with HIRES.' in fulltext
+    assert 'Thanks to Keck' in fulltext
+    assert 'The HIRES spectrograph' in fulltext
+    assert counts['HIRES']['count'] >= 3
+
+
+def test_get_word_match_counts_by_query_no_docs_returns_empty(monkeypatch):
+    monkeypatch.setattr(kpub_module, 'request_ads_api',
+                         MagicMock(return_value={'response': {'docs': []}}))
+
+    counts, fulltext = get_word_match_counts_by_query('2020ApJ...1A', ['HIRES'], 'KEY')
+
+    assert counts == {}
+    assert fulltext == ''
+
+
+def test_get_word_match_counts_by_query_escapes_ampersand_bibcode(monkeypatch):
+    mock_request = MagicMock(return_value={'response': {'docs': []}})
+    monkeypatch.setattr(kpub_module, 'request_ads_api', mock_request)
+
+    get_word_match_counts_by_query('2020A&A...1A', [], 'KEY')
+
+    called_url = mock_request.call_args[0][0]
+    assert '2020A%26A...1A' in called_url
+    assert '&' not in called_url.split('q=bibcode:%22')[1].split('%22')[0]
+
+
+# ---------------------------------------------------------------------------
+# get_word_match_counts_by_pdf / get_pdf_text
+# ---------------------------------------------------------------------------
+
+def test_get_word_match_counts_by_pdf_cleans_and_counts_text(monkeypatch):
+    monkeypatch.setattr(kpub_module, 'get_pdf_file', MagicMock(return_value='/tmp/fake.pdf'))
+    monkeypatch.setattr(kpub_module, 'get_pdf_text',
+                         MagicMock(return_value="Line one HIRES\nLine two\r\x00 HIRES again"))
+
+    counts, text = get_word_match_counts_by_pdf('2020ApJ...1A', ['HIRES'], 'KEY')
+
+    assert '\n' not in text
+    assert '\r' not in text
+    assert counts['HIRES']['count'] == 2
+
+
+def test_get_word_match_counts_by_pdf_raises_when_no_file(monkeypatch):
+    monkeypatch.setattr(kpub_module, 'get_pdf_file', MagicMock(return_value=False))
+
+    with pytest.raises(Exception, match='Could not download fulltext'):
+        get_word_match_counts_by_pdf('2020ApJ...1A', ['HIRES'], 'KEY')
+
+
+def test_get_word_match_counts_by_pdf_raises_when_no_text_extracted(monkeypatch):
+    # Regression test: a downloaded file that yields no extractable text (e.g. a
+    # bot-block/CAPTCHA page served instead of the real article) used to be
+    # silently treated as a successful "zero matches" result instead of a
+    # failure, which meant find_all_snippets never fell back to the
+    # ADS-metadata query method.
+    monkeypatch.setattr(kpub_module, 'get_pdf_file', MagicMock(return_value='/tmp/fake.html'))
+    monkeypatch.setattr(kpub_module, 'get_pdf_text', MagicMock(return_value=''))
+
+    with pytest.raises(Exception, match='No text could be extracted'):
+        get_word_match_counts_by_pdf('2020ApJ...1A', ['HIRES'], 'KEY')
+
+
+def test_get_pdf_text_html_uses_textract_bs4_parser(monkeypatch):
+    fake_textract = MagicMock()
+    fake_textract.process.return_value = b'hello html text'
+    monkeypatch.setattr(kpub_module, 'textract', fake_textract)
+
+    text = get_pdf_text('/tmp/2020ApJ...1A.html')
+
+    assert text == 'hello html text'
+    fake_textract.process.assert_called_once_with('/tmp/2020ApJ...1A.html')
+
+
+def test_get_pdf_text_pdf_falls_back_to_second_method(monkeypatch):
+    fake_textract = MagicMock()
+    fake_textract.process.side_effect = [Exception('pdftotext failed'), b'extracted via pdfminer']
+    monkeypatch.setattr(kpub_module, 'textract', fake_textract)
+
+    text = get_pdf_text('/tmp/2020ApJ...1A.pdf')
+
+    assert text == 'extracted via pdfminer'
+    assert fake_textract.process.call_count == 2
+
+
+def test_get_pdf_text_raises_when_all_methods_fail(monkeypatch):
+    fake_textract = MagicMock()
+    fake_textract.process.side_effect = Exception('boom')
+    monkeypatch.setattr(kpub_module, 'textract', fake_textract)
+
+    with pytest.raises(Exception, match='Could not extract PDF text'):
+        get_pdf_text('/tmp/2020ApJ...1A.pdf')
+
+
+# ---------------------------------------------------------------------------
+# get_pdf_file
+# ---------------------------------------------------------------------------
+
+def test_get_pdf_file_succeeds_on_first_esource(monkeypatch):
+    monkeypatch.setattr(kpub_module.os.path, 'isfile', MagicMock(return_value=False))
+    resp = MagicMock(status_code=200, content=b'x' * 2000, headers={'Content-Type': 'application/pdf'})
+    monkeypatch.setattr(kpub_module, 'request_ads_api', MagicMock(return_value=resp))
+    m_open = MagicMock()
+    monkeypatch.setattr('builtins.open', m_open)
+
+    outfile = get_pdf_file('2020ApJ...1A', 'KEY')
+
+    assert outfile == '/tmp/2020ApJ...1A.pdf'
+    m_open.assert_called_once_with('/tmp/2020ApJ...1A.pdf', 'wb')
+
+
+def test_get_pdf_file_uses_cached_file_if_present(monkeypatch):
+    monkeypatch.setattr(kpub_module.os.path, 'isfile', MagicMock(return_value=True))
+    mock_request = MagicMock()
+    monkeypatch.setattr(kpub_module, 'request_ads_api', mock_request)
+
+    outfile = get_pdf_file('2020ApJ...1A', 'KEY')
+
+    assert outfile == '/tmp/2020ApJ...1A.pdf'
+    mock_request.assert_not_called()
+
+
+def test_get_pdf_file_falls_back_through_esources(monkeypatch):
+    monkeypatch.setattr(kpub_module.os.path, 'isfile', MagicMock(return_value=False))
+    bad_resp = MagicMock(status_code=200, content=b'x' * 2000,
+                          headers={'Content-Type': 'text/html'})  # wrong type for a *_PDF esource
+    good_resp = MagicMock(status_code=200, content=b'x' * 2000,
+                           headers={'Content-Type': 'text/html'})  # right type for EPRINT_HTML
+    mock_request = MagicMock(side_effect=[Exception('network error'), bad_resp, good_resp])
+    monkeypatch.setattr(kpub_module, 'request_ads_api', mock_request)
+    monkeypatch.setattr('builtins.open', MagicMock())
+
+    outfile = get_pdf_file('2020ApJ...1A', 'KEY')
+
+    # 3rd esource in FULLTEXT_ESOURCES is EPRINT_HTML -> .html extension
+    assert outfile == '/tmp/2020ApJ...1A.html'
+    assert mock_request.call_count == 3
+
+
+def test_get_pdf_file_returns_false_when_all_esources_fail(monkeypatch):
+    monkeypatch.setattr(kpub_module.os.path, 'isfile', MagicMock(return_value=False))
+    monkeypatch.setattr(kpub_module, 'request_ads_api', MagicMock(side_effect=Exception('nope')))
+
+    outfile = get_pdf_file('2020ApJ...1A', 'KEY')
+
+    assert outfile is False
+
+
+def test_get_pdf_file_rejects_short_content(monkeypatch):
+    monkeypatch.setattr(kpub_module.os.path, 'isfile', MagicMock(return_value=False))
+    short_resp = MagicMock(status_code=200, content=b'tiny', headers={'Content-Type': 'application/pdf'})
+    monkeypatch.setattr(kpub_module, 'request_ads_api', MagicMock(return_value=short_resp))
+
+    outfile = get_pdf_file('2020ApJ...1A', 'KEY')
+
+    assert outfile is False
+
+
+# ---------------------------------------------------------------------------
+# get_citation_fields / update_citations / kpub_update_citations
+# ---------------------------------------------------------------------------
+
+def test_get_citation_fields_returns_first_doc(monkeypatch):
+    fake_data = {'response': {'docs': [{'citation_count': 42}]}}
+    monkeypatch.setattr(kpub_module, 'request_ads_api', MagicMock(return_value=fake_data))
+
+    fields = get_citation_fields('2020ApJ...1A', 'KEY')
+
+    assert fields == {'citation_count': 42}
+
+
+def test_get_citation_fields_returns_false_when_missing(monkeypatch):
+    monkeypatch.setattr(kpub_module, 'request_ads_api',
+                         MagicMock(return_value={'response': {'docs': []}}))
+
+    assert get_citation_fields('2020ApJ...1A', 'KEY') is False
+
+
+def test_update_citations_updates_only_keck_articles(monkeypatch, config):
+    monkeypatch.setattr(kpub_module, 'yaml',
+                         MagicMock(load=MagicMock(return_value=config), FullLoader=None))
+    monkeypatch.setattr('builtins.open', MagicMock())
+
+    fake_pubdb = MagicMock()
+    fake_pubdb.query.return_value = [
+        {'bibcode': '2020ApJ...1A', 'affiliation': 'keck'},
+        {'bibcode': '2020ApJ...2B', 'affiliation': 'unrelated'},
+    ]
+    monkeypatch.setattr(kpub_module, 'PublicationDB', MagicMock(return_value=fake_pubdb))
+    monkeypatch.setattr(kpub_module, 'get_citation_fields',
+                         MagicMock(return_value={'citation_count': 7}))
+
+    update_citations('2020')
+
+    fake_pubdb.update_citation_fields.assert_called_once_with('2020ApJ...1A', {'citation_count': 7})
+
+
+def test_update_citations_skips_when_citation_fields_missing(monkeypatch, config):
+    monkeypatch.setattr(kpub_module, 'yaml',
+                         MagicMock(load=MagicMock(return_value=config), FullLoader=None))
+    monkeypatch.setattr('builtins.open', MagicMock())
+
+    fake_pubdb = MagicMock()
+    fake_pubdb.query.return_value = [{'bibcode': '2020ApJ...1A', 'affiliation': 'keck'}]
+    monkeypatch.setattr(kpub_module, 'PublicationDB', MagicMock(return_value=fake_pubdb))
+    monkeypatch.setattr(kpub_module, 'get_citation_fields', MagicMock(return_value=False))
+
+    update_citations('2020')
+
+    fake_pubdb.update_citation_fields.assert_not_called()
+
+
+def test_kpub_update_citations_delegates_to_update_citations(monkeypatch):
+    mock_update = MagicMock()
+    monkeypatch.setattr(kpub_module, 'update_citations', mock_update)
+
+    kpub_update_citations('2021')
+
+    mock_update.assert_called_once_with('2021')
+
+
+# ---------------------------------------------------------------------------
+# prompt helpers
+# ---------------------------------------------------------------------------
+
+def test_add_prompt_valmaps_appends_1_indexed_keys():
+    valmap = {'0': 'unrelated'}
+    result = add_prompt_valmaps(dict(valmap), ['keck', 'other'])
+    assert result == {'0': 'unrelated', '1': 'keck', '2': 'other'}
+
+
+def test_prompt_grouping_returns_user_input(monkeypatch):
+    monkeypatch.setattr('builtins.input', MagicMock(return_value='1'))
+    result = prompt_grouping({'1': 'keck'}, 'Mission')
+    assert result == '1'
+
+
+def test_input_with_prefill_uses_readline_hook(monkeypatch):
+    monkeypatch.setattr(kpub_module.readline, 'set_pre_input_hook', MagicMock())
+    monkeypatch.setattr('builtins.input', MagicMock(return_value='typed value'))
+
+    result = input_with_prefill('prompt> ', 'prefill text')
+
+    assert result == 'typed value'
+    assert kpub_module.readline.set_pre_input_hook.call_count == 2

--- a/src/tests/test_kpub_publicationdb.py
+++ b/src/tests/test_kpub_publicationdb.py
@@ -115,6 +115,7 @@ def test_add_inserts_row_with_expected_fields(db):
     assert inserted['affiliation'] == 'keck'
     assert inserted['last_modifier'] == 'kpub'
     assert isinstance(inserted['date_modified'], datetime.datetime)
+    assert inserted['date_created'] == inserted['date_modified']
 
 
 def test_add_swallows_duplicate_key_error(db, caplog):
@@ -259,6 +260,18 @@ def test_set_affiliation_updates_fields_and_returns_updated_articles(db):
     db.collection.update_one.assert_called_once()
     filter_arg = db.collection.update_one.call_args[0][0]
     assert filter_arg == {'_id': '2020ApJ...1A'}
+
+
+def test_set_affiliation_does_not_touch_date_created(db):
+    # Regression test: date_created must be set once at insert time (add_row)
+    # and never overwritten by later updates such as set_affiliation.
+    article = {'_id': '2020ApJ...1A', 'bibcode': '2020ApJ...1A',
+               'date_created': 'original-creation-date'}
+
+    db.set_affiliation([article], last_modifier='tester', affiliation='keck')
+
+    update_arg = db.collection.update_one.call_args[0][1]
+    assert 'date_created' not in update_arg['$set']
 
 
 # ---------------------------------------------------------------------------

--- a/src/tests/test_kpub_publicationdb.py
+++ b/src/tests/test_kpub_publicationdb.py
@@ -1,0 +1,617 @@
+"""Unit tests for kpub.PublicationDB methods.
+
+The MongoDB client/collection are mocked (see conftest.py); no test here
+ever opens a real network connection. Methods that PublicationDB inherits
+from MongoDBConnector (query, add_row, article_exists, update_row_affiliation,
+get_articles_by_mission_years, get_articles_by_years_instrument,
+get_count_cumulative) are treated as the database boundary and are mocked
+directly where a test's target method depends on them, so that each test
+exercises only the logic that actually lives in kpub.py.
+"""
+import datetime
+from unittest.mock import MagicMock
+
+import pymongo
+import pytest
+
+import kpub as kpub_module
+
+
+# ---------------------------------------------------------------------------
+# get_affiliation
+# ---------------------------------------------------------------------------
+
+def test_get_affiliation_acknowledgement_found(db):
+    snippits = {'W. M. Keck Foundation': {'count': 1, 'snippets': []}}
+    affiliation, has_ack, reason = db.get_affiliation(snippits, mission='pipeline')
+    assert affiliation == 'keck'
+    assert has_ack is True
+    assert reason == 'Acknowledgement found in snippets.'
+
+
+def test_get_affiliation_instruments_found(db):
+    snippits = {'HIRES': {'count': 1, 'snippets': []}}
+    affiliation, has_ack, reason = db.get_affiliation(snippits, mission='keck')
+    assert affiliation == 'keck'
+    assert has_ack is False
+    assert reason == 'Instrument names found in snippets.'
+
+
+def test_get_affiliation_nothing_found_non_keck_mission(db):
+    affiliation, has_ack, reason = db.get_affiliation({}, mission='unrelated')
+    assert affiliation == 'unknown'
+    assert has_ack is False
+    assert reason == 'No instrument names found in snippets.'
+
+
+def test_get_affiliation_nothing_found_keck_mission(db):
+    affiliation, has_ack, reason = db.get_affiliation({}, mission='keck')
+    assert affiliation == 'unknown'
+    assert has_ack is False
+    assert reason == 'Neither instr nor ack found.'
+
+
+# ---------------------------------------------------------------------------
+# get_archive_acknowledgement
+# ---------------------------------------------------------------------------
+
+def test_get_archive_acknowledgement_found(db):
+    assert db.get_archive_acknowledgement({'KOA': {}}) is True
+
+
+def test_get_archive_acknowledgement_not_found(db):
+    assert db.get_archive_acknowledgement({'HIRES': {}}) is False
+
+
+def test_get_archive_acknowledgement_not_configured(config):
+    config = dict(config)
+    config['archive'] = []
+    db = kpub_module.PublicationDB(config=config, collection='articles')
+    assert db.get_archive_acknowledgement({'anything': {}}) == ''
+
+
+# ---------------------------------------------------------------------------
+# get_aff_type
+# ---------------------------------------------------------------------------
+
+def test_get_aff_type_blank_string_returns_none(db):
+    assert db.get_aff_type('-', db.config['aff_defs']) is None
+    assert db.get_aff_type('', db.config['aff_defs']) is None
+
+
+def test_get_aff_type_matches_keck(db):
+    result = db.get_aff_type('Keck Observatory, Hawaii', db.config['aff_defs'])
+    assert result == 'keck'
+
+
+def test_get_aff_type_matches_usa_case_sensitive(db):
+    result = db.get_aff_type('NASA Ames Research Center', db.config['aff_defs'])
+    assert result == 'usa'
+
+
+def test_get_aff_type_falls_back_to_default(db):
+    result = db.get_aff_type('University of Tokyo, Japan', db.config['aff_defs'])
+    assert result == 'intl'
+
+
+# ---------------------------------------------------------------------------
+# add
+# ---------------------------------------------------------------------------
+
+def test_add_inserts_row_with_expected_fields(db):
+    article = {'bibcode': '2020ApJ...1A', 'pubdate': '2020-05-00', 'title': ['A title']}
+
+    db.add(article, mission='keck', snippits={'HIRES': {'count': 1, 'snippets': []}},
+           instruments='HIRES', archive=False, affiliation='keck',
+           reason='Instrument names found in snippets.', hasAcknowledgement=False)
+
+    db.collection.insert_one.assert_called_once()
+    inserted = db.collection.insert_one.call_args[0][0]
+    assert inserted['_id'] == '2020ApJ...1A'
+    assert inserted['month'] == 5
+    assert inserted['year'] == 2020
+    assert inserted['mission'] == 'keck'
+    assert inserted['instruments'] == ['HIRES']
+    assert inserted['affiliation'] == 'keck'
+    assert inserted['last_modifier'] == 'kpub'
+    assert isinstance(inserted['date_modified'], datetime.datetime)
+
+
+def test_add_swallows_duplicate_key_error(db, caplog):
+    article = {'bibcode': '2020ApJ...1A', 'pubdate': '2020-05-00'}
+    db.collection.insert_one.side_effect = pymongo.errors.DuplicateKeyError('dup')
+
+    with caplog.at_level('WARNING', logger='KPUB'):
+        db.add(article, mission='keck', snippits={}, instruments='',
+               archive=False, affiliation='keck', reason='r', hasAcknowledgement=False)
+
+    assert any('already been ingested' in r.message or 'already ingested' in r.message
+               for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# add_article
+# ---------------------------------------------------------------------------
+
+def test_add_article_skips_existing_article(db):
+    db.collection.count_documents.return_value = 1
+    article = {'id': '123', 'bibcode': '2020ApJ...1A'}
+
+    result = db.add_article(article)
+
+    assert result == 0
+
+
+def test_add_article_adds_new_article_with_snippets(db, monkeypatch):
+    db.collection.count_documents.return_value = 0
+    article = {'id': '123', 'bibcode': '2020ApJ...1A'}
+    monkeypatch.setattr(db, 'find_all_snippets',
+                         MagicMock(return_value={'HIRES': {'count': 1, 'snippets': ['abc']}}))
+    monkeypatch.setattr(db, 'add', MagicMock(return_value=1))
+
+    result = db.add_article(article, interactive=False)
+
+    assert result == 1
+    db.add.assert_called_once()
+    _, kwargs = db.add.call_args
+    assert kwargs['mission'] == 'keck'
+    assert kwargs['instruments'] == 'HIRES'
+    assert kwargs['affiliation'] == 'keck'
+
+
+def test_add_article_marks_unrelated_when_no_snippets(db, monkeypatch):
+    db.collection.count_documents.return_value = 0
+    article = {'id': '123', 'bibcode': '2020ApJ...1A'}
+    monkeypatch.setattr(db, 'find_all_snippets', MagicMock(return_value={}))
+    monkeypatch.setattr(db, 'add', MagicMock(return_value=1))
+
+    db.add_article(article, interactive=False)
+
+    _, kwargs = db.add.call_args
+    assert kwargs['mission'] == 'unknown'
+    assert kwargs['instruments'] == ''
+
+
+# ---------------------------------------------------------------------------
+# find_all_snippets
+# ---------------------------------------------------------------------------
+
+def test_find_all_snippets_uses_pdf_method_and_saves_fulltext(db, monkeypatch):
+    counts = {'HIRES': {'count': 1, 'snippets': ['abc']}}
+    monkeypatch.setattr(kpub_module, 'get_word_match_counts_by_pdf',
+                         MagicMock(return_value=(counts, 'the full text')))
+    monkeypatch.setattr(kpub_module, 'get_word_match_counts_by_query', MagicMock())
+    monkeypatch.setattr(db, 'save_fulltext', MagicMock())
+
+    result = db.find_all_snippets('2020ApJ...1A')
+
+    assert result == counts
+    db.save_fulltext.assert_called_once_with('2020ApJ...1A', 'the full text')
+    kpub_module.get_word_match_counts_by_query.assert_not_called()
+
+
+def test_find_all_snippets_falls_back_to_query_method_on_pdf_failure(db, monkeypatch):
+    counts = {'HIRES': {'count': 2, 'snippets': ['xyz']}}
+    monkeypatch.setattr(kpub_module, 'get_word_match_counts_by_pdf',
+                         MagicMock(side_effect=Exception('no pdf')))
+    monkeypatch.setattr(kpub_module, 'get_word_match_counts_by_query',
+                         MagicMock(return_value=(counts, 'query-sourced text')))
+    monkeypatch.setattr(db, 'save_fulltext', MagicMock())
+
+    result = db.find_all_snippets('2020ApJ...1A')
+
+    assert result == counts
+    db.save_fulltext.assert_called_once_with('2020ApJ...1A', 'query-sourced text')
+
+
+def test_find_all_snippets_returns_empty_list_when_no_configured_words(config, monkeypatch):
+    config = dict(config)
+    config.update({'missions': [], 'instruments': [], 'acknowledgement': [], 'archive': []})
+    db = kpub_module.PublicationDB(config=config, collection='articles')
+    mock_pdf = MagicMock()
+    monkeypatch.setattr(kpub_module, 'get_word_match_counts_by_pdf', mock_pdf)
+
+    result = db.find_all_snippets('2020ApJ...1A')
+
+    assert result == []
+    mock_pdf.assert_not_called()
+
+
+def test_find_all_snippets_does_not_save_when_no_fulltext(db, monkeypatch):
+    monkeypatch.setattr(kpub_module, 'get_word_match_counts_by_pdf',
+                         MagicMock(return_value=({}, '')))
+    monkeypatch.setattr(db, 'save_fulltext', MagicMock())
+
+    db.find_all_snippets('2020ApJ...1A')
+
+    db.save_fulltext.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# save_fulltext
+# ---------------------------------------------------------------------------
+
+def test_save_fulltext_delegates_to_upsert_fulltext(db, monkeypatch):
+    monkeypatch.setattr(db, 'upsert_fulltext', MagicMock())
+
+    db.save_fulltext('2020ApJ...1A', 'the plaintext')
+
+    db.upsert_fulltext.assert_called_once_with('2020ApJ...1A', 'the plaintext')
+
+
+# ---------------------------------------------------------------------------
+# set_affiliation
+# ---------------------------------------------------------------------------
+
+def test_set_affiliation_updates_fields_and_returns_updated_articles(db):
+    article = {'_id': '2020ApJ...1A', 'bibcode': '2020ApJ...1A'}
+
+    result = db.set_affiliation([article], last_modifier='tester', affiliation='keck',
+                                 koa_affiliation=True, instruments=['HIRES'], note='a note')
+
+    assert len(result) == 1
+    updated = result[0]
+    assert updated['affiliation'] == 'keck'
+    assert updated['archive'] is True
+    assert updated['instruments'] == ['HIRES']
+    assert updated['note'] == 'a note'
+    assert updated['last_modifier'] == 'tester'
+    db.collection.update_one.assert_called_once()
+    filter_arg = db.collection.update_one.call_args[0][0]
+    assert filter_arg == {'_id': '2020ApJ...1A'}
+
+
+# ---------------------------------------------------------------------------
+# add_by_bibcode
+# ---------------------------------------------------------------------------
+
+def test_add_by_bibcode_adds_matching_article(db, monkeypatch):
+    monkeypatch.setattr(db, 'query_ads', MagicMock(return_value={
+        'response': {'docs': [{'bibcode': '2020ApJ...1A', 'property': ['REFEREED']}]}
+    }))
+    monkeypatch.setattr(db, 'add_article', MagicMock())
+
+    db.add_by_bibcode('2020ApJ...1A', interactive=False)
+
+    db.query_ads.assert_called_once_with('identifier:2020ApJ...1A')
+    db.add_article.assert_called_once_with(
+        {'bibcode': '2020ApJ...1A', 'property': ['REFEREED']}, interactive=False)
+
+
+def test_add_by_bibcode_logs_error_when_no_articles_found(db, monkeypatch, caplog):
+    monkeypatch.setattr(db, 'query_ads', MagicMock(return_value={'response': {'docs': []}}))
+    monkeypatch.setattr(db, 'add_article', MagicMock())
+
+    with caplog.at_level('ERROR', logger='KPUB'):
+        db.add_by_bibcode('2020ApJ...1A')
+
+    assert any('No ADS record found' in r.message for r in caplog.records)
+    db.add_article.assert_not_called()
+
+
+def test_add_by_bibcode_skips_nonarticle_when_interactive(db, monkeypatch):
+    monkeypatch.setattr(db, 'query_ads', MagicMock(return_value={
+        'response': {'docs': [{'bibcode': '2020ApJ...1A', 'property': ['NONARTICLE']}]}
+    }))
+    monkeypatch.setattr(db, 'add_article', MagicMock())
+
+    db.add_by_bibcode('2020ApJ...1A', interactive=True)
+
+    db.add_article.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# to_markdown / save_markdown
+# ---------------------------------------------------------------------------
+
+def test_to_markdown_renders_articles_grouped_by_year(db):
+    rows = [{
+        'year': 2020, 'title': ['a great paper'], 'bibcode': '2020ApJ...1A',
+        'author': ['Smith, J.', 'Doe, A.'], 'pub': 'ApJ', 'property': ['REFEREED'],
+    }]
+    db.collection.find.return_value.sort.return_value = rows
+
+    markdown = db.to_markdown(title='Test Publications')
+
+    assert 'A GREAT PAPER' in markdown
+    assert '2020ApJ...1A' in markdown
+    assert 'Smith, J.' in markdown
+
+
+def test_to_markdown_handles_none_property(db):
+    rows = [{
+        'year': 2020, 'title': ['t'], 'bibcode': '2020ApJ...1A',
+        'author': ['Smith, J.'], 'pub': 'ApJ', 'property': None,
+    }]
+    db.collection.find.return_value.sort.return_value = rows
+
+    markdown = db.to_markdown()
+
+    assert '2020ApJ...1A' in markdown
+
+
+def test_save_markdown_writes_file(db, monkeypatch, tmp_path):
+    monkeypatch.setattr(db, 'to_markdown', MagicMock(return_value='MARKDOWN CONTENT'))
+    output_fn = str(tmp_path / 'out.md')
+
+    db.save_markdown(output_fn)
+
+    assert (tmp_path / 'out.md').read_text() == 'MARKDOWN CONTENT'
+    db.to_markdown.assert_called_once()
+    assert db.to_markdown.call_args.kwargs['save_as'] == str(tmp_path / 'out.html')
+
+
+# ---------------------------------------------------------------------------
+# get_plot_data / get_plot
+# ---------------------------------------------------------------------------
+
+def test_get_plot_data_by_year(db, monkeypatch):
+    mock_fn = MagicMock(return_value={'x': [1], 'y': [2]})
+    monkeypatch.setattr(kpub_module.plot, 'get_plot_by_year_data', mock_fn)
+
+    result = db.get_plot_data('plot_by_year')
+
+    assert result == {'x': [1], 'y': [2]}
+    mock_fn.assert_called_once_with(db, year_begin=2009, extrapolate=True)
+
+
+def test_get_plot_data_author_count(db, monkeypatch):
+    mock_fn = MagicMock(return_value={'authors': 3})
+    monkeypatch.setattr(kpub_module.plot, 'get_plot_author_count_data', mock_fn)
+
+    result = db.get_plot_data('plot_author_count', year_begin=2015)
+
+    assert result == {'authors': 3}
+    mock_fn.assert_called_once_with(db, year_begin=2015)
+
+
+def test_get_plot_data_by_instrument_uses_config_instruments_by_default(db, monkeypatch):
+    mock_fn = MagicMock(return_value=({'HIRES': 5}, 'ignored'))
+    monkeypatch.setattr(kpub_module.plot, 'get_plot_instruments_data', mock_fn)
+
+    result = db.get_plot_data('plot_by_instrument')
+
+    assert result == {'HIRES': 5}
+    _, kwargs = mock_fn.call_args
+    assert kwargs['instruments'] == ['HIRES', 'LRIS']
+
+
+def test_get_plot_data_unknown_plotname_raises(db):
+    with pytest.raises(ValueError):
+        db.get_plot_data('not_a_real_plot')
+
+
+def test_get_plot_calls_all_plot_functions(db, monkeypatch):
+    mocks = {
+        'plot_by_year': MagicMock(),
+        'plot_author_count': MagicMock(),
+        'plot_instruments': MagicMock(),
+        'plot_affiliations': MagicMock(),
+    }
+    for name, mock in mocks.items():
+        monkeypatch.setattr(kpub_module.plot, name, mock)
+
+    db.get_plot()
+
+    assert mocks['plot_by_year'].call_count == 4  # 2 extensions x 2 variants
+    assert mocks['plot_author_count'].call_count == 2  # 2 extensions
+    mocks['plot_instruments'].assert_called_once()
+    mocks['plot_affiliations'].assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# get_metrics
+# ---------------------------------------------------------------------------
+
+def test_get_metrics_computes_expected_statistics(db, monkeypatch):
+    articles = [
+        {'mission': 'keck', 'bibcode': '2020ApJ...1A', 'author_norm': ['Smith, J.', 'Doe, A.'],
+         'first_author_norm': 'Smith, J.', 'property': ['REFEREED'], 'citation_count': 5},
+        {'mission': 'keck', 'bibcode': '2020PhDT....1A', 'author_norm': ['Lee, K.'],
+         'first_author_norm': 'Lee, K.', 'property': ['NOT REFEREED'], 'citation_count': 2},
+        {'mission': 'unrelated', 'bibcode': '2020ApJ...3C', 'author_norm': ['Doe, A.'],
+         'first_author_norm': 'Doe, A.', 'property': None},
+    ]
+    monkeypatch.setattr(db, 'query', MagicMock(return_value=articles))
+
+    metrics = db.get_metrics()
+
+    assert metrics['publication_count'] == 3
+    assert metrics['keck_count'] == 2
+    assert metrics['unrelated_count'] == 1
+    assert metrics['phd_count'] == 1
+    assert metrics['keck_phd_count'] == 1
+    assert metrics['refereed_count'] == 1
+    assert metrics['citation_count'] == 7
+    assert metrics['author_count'] == 3
+    assert metrics['first_author_count'] == 3
+    assert metrics['keck_fraction'] == pytest.approx(2 / 3)
+
+
+# ---------------------------------------------------------------------------
+# get_all / get_most_cited / get_most_read / get_most_active_first_authors / get_all_authors
+# ---------------------------------------------------------------------------
+
+def test_get_all_delegates_to_query(db, monkeypatch):
+    monkeypatch.setattr(db, 'query', MagicMock(return_value=['article1']))
+
+    result = db.get_all(mission='keck')
+
+    assert result == ['article1']
+    db.query.assert_called_once_with(mission='keck')
+
+
+def test_get_most_cited_orders_by_citation_count_desc(db, monkeypatch):
+    articles = [
+        {'bibcode': 'A', 'citation_count': 5},
+        {'bibcode': 'B', 'citation_count': None},
+        {'bibcode': 'C', 'citation_count': 10},
+    ]
+    monkeypatch.setattr(db, 'query', MagicMock(return_value=articles))
+
+    top = db.get_most_cited(top=2)
+
+    assert [a['bibcode'] for a in top] == ['C', 'A']
+
+
+def test_get_most_read_orders_by_read_count_desc(db, monkeypatch):
+    articles = [
+        {'bibcode': 'A', 'read_count': 5},
+        {'bibcode': 'B', 'read_count': 20},
+        {'bibcode': 'C', 'read_count': 1},
+    ]
+    monkeypatch.setattr(db, 'query', MagicMock(return_value=articles))
+
+    top = db.get_most_read(top=2)
+
+    assert [a['bibcode'] for a in top] == ['B', 'A']
+
+
+def test_get_most_active_first_authors_filters_by_min_papers(db, monkeypatch):
+    articles = (
+        [{'first_author_norm': 'Smith, J.'}] * 3
+        + [{'first_author_norm': 'Doe, A.'}] * 1
+    )
+    monkeypatch.setattr(db, 'query', MagicMock(return_value=articles))
+
+    result = dict(db.get_most_active_first_authors(min_papers=2))
+
+    assert result == {'Smith, J.': 3}
+
+
+def test_get_all_authors_counts_co_authors(db, monkeypatch):
+    articles = [
+        {'author_norm': ['Smith, J.', 'Doe, A.']},
+        {'author_norm': ['Smith, J.']},
+    ]
+    monkeypatch.setattr(db, 'query', MagicMock(return_value=articles))
+
+    names, counts = db.get_all_authors(top=5)
+
+    name_to_count = dict(zip(names, counts))
+    assert name_to_count['Smith, J.'] == 2
+    assert name_to_count['Doe, A.'] == 1
+
+
+# ---------------------------------------------------------------------------
+# get_affiliation_counts
+# ---------------------------------------------------------------------------
+
+def test_get_affiliation_counts_first_author_and_top3(db, monkeypatch):
+    monkeypatch.setattr(db, 'get_articles_by_mission_years', MagicMock(return_value=[
+        {'year': 2020, 'aff': ['Keck Observatory', 'NASA Ames', 'Somewhere Else']},
+    ]))
+
+    counts = db.get_affiliation_counts(2020, 2020, 'keck')
+
+    assert counts['first author keck'][2020] == 1
+    assert counts['top3 authors keck'][2020] == 0
+
+
+def test_get_affiliation_counts_top3_all_same_type(db, monkeypatch):
+    monkeypatch.setattr(db, 'get_articles_by_mission_years', MagicMock(return_value=[
+        {'year': 2020, 'aff': ['Keck A', 'Keck B', 'Keck C']},
+    ]))
+
+    counts = db.get_affiliation_counts(2020, 2020, 'keck')
+
+    assert counts['top3 authors keck'][2020] == 1
+
+
+# ---------------------------------------------------------------------------
+# get_annual_publication_count / get_annual_publication_count_cumulative
+# ---------------------------------------------------------------------------
+
+def test_get_annual_publication_count_delegates(db, monkeypatch):
+    mock_fn = MagicMock(return_value={2010: 0, 2011: 5})
+    monkeypatch.setattr(db, 'get_articles_by_years_instrument', mock_fn)
+
+    result = db.get_annual_publication_count(year_begin=2010, year_end=2011, instrument='HIRES')
+
+    assert result == {2010: 0, 2011: 5}
+    mock_fn.assert_called_once_with(2010, 2011, 'HIRES')
+
+
+def test_get_annual_publication_count_cumulative_sums_per_year(db, monkeypatch):
+    monkeypatch.setattr(db, 'get_count_cumulative', MagicMock(side_effect=lambda y: int(y) - 2008))
+
+    result = db.get_annual_publication_count_cumulative(year_begin=2009, year_end=2011)
+
+    assert result == {2009: 1, 2010: 2, 2011: 3}
+
+
+# ---------------------------------------------------------------------------
+# update
+# ---------------------------------------------------------------------------
+
+def test_update_skips_articles_without_abstract_or_matching_bibcode_patterns(db, monkeypatch):
+    monkeypatch.setattr(db, 'query_ads', MagicMock(return_value={'response': {'docs': [
+        {'bibcode': '2020ApJ...1A'},  # no abstract -> skipped
+        {'bibcode': '2020A&A..prop..1B', 'abstract': 'x'},  # .prop. -> skipped
+        {'bibcode': '2020cosp..1234C', 'abstract': 'x'},  # cosp.. -> skipped
+        {'bibcode': '2020ApJ.tmp.1D', 'abstract': 'x'},  # .tmp -> skipped
+        {'bibcode': '2020ApJ...2E', 'abstract': 'A real abstract'},  # kept
+    ]}}))
+    monkeypatch.setattr(db, 'add_article', MagicMock(return_value=1))
+
+    success, num_added = db.update(month='2020-05')
+
+    assert success is True
+    assert num_added == 1
+    db.add_article.assert_called_once()
+    called_article = db.add_article.call_args[0][0]
+    assert called_article['bibcode'] == '2020ApJ...2E'
+    db.query_ads.assert_called_once_with(db.config['ads_queries'][0]['query'], '2020-05')
+
+
+def test_update_defaults_to_current_month(db, monkeypatch):
+    monkeypatch.setattr(db, 'query_ads', MagicMock(return_value={'response': {'docs': []}}))
+
+    db.update()
+
+    args = db.query_ads.call_args[0]
+    assert len(args) == 2
+    import re as _re
+    assert _re.match(r'^\d{4}-\d{2}$', args[1])
+
+
+# ---------------------------------------------------------------------------
+# open_pdf
+# ---------------------------------------------------------------------------
+
+def test_open_pdf_opens_browser_when_file_exists(db, monkeypatch):
+    monkeypatch.setattr(kpub_module, 'get_pdf_file', MagicMock(return_value='/tmp/fake.pdf'))
+    monkeypatch.setattr(kpub_module.os.path, 'isfile', MagicMock(return_value=True))
+    monkeypatch.setattr(kpub_module.webbrowser, 'open', MagicMock())
+
+    db.open_pdf('2020ApJ...1A')
+
+    kpub_module.webbrowser.open.assert_called_once()
+    assert 'fake.pdf' in kpub_module.webbrowser.open.call_args[0][0]
+
+
+def test_open_pdf_does_nothing_when_file_missing(db, monkeypatch):
+    monkeypatch.setattr(kpub_module, 'get_pdf_file', MagicMock(return_value=False))
+    monkeypatch.setattr(kpub_module.os.path, 'isfile', MagicMock(return_value=False))
+    monkeypatch.setattr(kpub_module.webbrowser, 'open', MagicMock())
+
+    db.open_pdf('2020ApJ...1A')
+
+    kpub_module.webbrowser.open.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# query_ads
+# ---------------------------------------------------------------------------
+
+def test_query_ads_builds_expected_url_and_returns_data(db, monkeypatch):
+    mock_request = MagicMock(return_value={'response': {'docs': []}})
+    monkeypatch.setattr(kpub_module, 'request_ads_api', mock_request)
+
+    result = db.query_ads('ack:"keck observatory"', pubdate='2020-05')
+
+    assert result == {'response': {'docs': []}}
+    called_url, called_key = mock_request.call_args[0]
+    assert called_key == 'FAKE-ADS-API-KEY'
+    assert 'ack:%22keck+observatory%22' in called_url
+    assert 'pubdate:2020-05' in called_url


### PR DESCRIPTION
* Saves paper to fulltext collection. Attempts to save direct query, then pdf, then html.
* articles include date_created field
* frontend table sorts dates properly
* Include script that checks articles have a fulltext paper available.
* No snippets found marks article as unknown (previously set to unaffiliated)
* Includes unit tests!